### PR TITLE
Added invalid param HTTP status code 422

### DIFF
--- a/lib/exceptionally/controller.rb
+++ b/lib/exceptionally/controller.rb
@@ -12,7 +12,7 @@ module Exceptionally
       rescue_from ActiveRecord::RecordInvalid, :with => :record_invalid_handler
       if defined?(Apipie)
         rescue_from Apipie::ParamMissing, :with => :missing_param
-        rescue_from Apipie::ParamInvalid, :with => :missing_param
+        rescue_from Apipie::ParamInvalid, :with => :invalid_param
       end
     end
 
@@ -34,6 +34,11 @@ module Exceptionally
     # Raise 409 error
     def record_invalid_handler(error)
       pass_to_error_handler(error, 409)
+    end
+    
+    # Raise 422 error
+    def invalid_param(error)
+      pass_to_error_handler(error, 422)
     end
 
     def pass_to_error_handler(error, status = nil)


### PR DESCRIPTION
The 422 status code seems to be made for the invalid parameter case (https://tools.ietf.org/html/rfc4918#section-11.2), and is probably a more valid fit than the generic 400 error code.  

See also: http://stackoverflow.com/questions/16133923/400-vs-422-response-to-post-of-data
