### PR TITLE
pass the whole error object to render_error hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,14 +73,14 @@ end
 You can also override the returned response by adding a `render_error` method to your controller. For example, if you want to include the HTTP status code in the returned JSON, you can do:
 
 ```ruby
-def render_error(message, status)
-  render json: {error_message: message, error_status: status}, status: status
+def render_error(error, status)
+  render json: {error_message: error.message, error_status: status}, status: status
 end
 ```
 
 You could also return HTML, XML, or whatever other format is relevant to your application.
 
-`render_error` must accept `message`, a string description of the error, and `status`, an integer HTTP status code.
+`render_error` must accept `error`, the StandardError object that was raised, and `status`, an integer HTTP status code.
 
 #### Add custom errors
 

--- a/lib/exceptionally/controller.rb
+++ b/lib/exceptionally/controller.rb
@@ -43,7 +43,7 @@ module Exceptionally
     def record_invalid_handler(error)
       pass_to_error_handler(error, 409)
     end
-    
+
     # Raise 422 error
     def invalid_param(error)
       pass_to_error_handler(error, 422)
@@ -52,11 +52,11 @@ module Exceptionally
     def pass_to_error_handler(error, status = nil)
       status ||= error.try(:status) || 500
       Exceptionally::Handler.new(error.message, status, error, params)
-      render_error(error.message, status)
+      render_error(error, status)
     end
 
-    def render_error(message, status)
-      render json: {error: message}, status: status
+    def render_error(error, status)
+      render json: {error: error.message}, status: status
     end
 
   end


### PR DESCRIPTION
gives the user more flexibility in their custom error formatting
